### PR TITLE
Add the possibility to delete local data

### DIFF
--- a/cate/core/ds.py
+++ b/cate/core/ds.py
@@ -171,7 +171,7 @@ class DataSource(metaclass=ABCMeta):
                ``datetime.datetime`` objects.
         :return: removed number of files
         """
-        return 0, 0
+        return 0
 
     @property
     def meta_info(self) -> Union[dict, None]:

--- a/cate/core/ds.py
+++ b/cate/core/ds.py
@@ -161,6 +161,18 @@ class DataSource(metaclass=ABCMeta):
         """
         return 0, 0
 
+    def delete_local(self,
+                     time_range: Tuple[datetime, datetime]) -> int:
+        """
+        Delete locally stored data.
+        The default implementation does nothing.
+
+        :param time_range: An optional tuple comprising a start and end date, which must be
+               ``datetime.datetime`` objects.
+        :return: removed number of files
+        """
+        return 0, 0
+
     @property
     def meta_info(self) -> Union[dict, None]:
         """

--- a/cate/ds/esa_cci_odp.py
+++ b/cate/ds/esa_cci_odp.py
@@ -476,6 +476,25 @@ class EsaCciOdpDataSource(DataSource):
 
         return len(outdated_file_list), len(selected_file_list)
 
+    def delete_local(self, time_range: Tuple[datetime, datetime]) -> int:
+        selected_file_list = self._find_files(time_range)
+        if not selected_file_list:
+            return 0
+
+        dataset_dir = self.local_dataset_dir()
+        removed_count = 0
+
+        for filename, _, _, _, _ in selected_file_list:
+            dataset_file = os.path.join(dataset_dir, filename)
+            try:
+                os.remove(dataset_file)
+                removed_count += 1
+            except:
+                # File busy on Windows, move on
+                pass
+
+        return removed_count
+
     def local_dataset_dir(self):
         return os.path.join(get_data_store_path(), self._master_id)
 


### PR DESCRIPTION
Odp data store can now delete local data. The feature stub has also been
added to the parent class.

resolves #107 

I implemented local data deletion as part of data source implementation, as it made sense to me. However, if this is something you don't like for some reason architecturally, I can of course do the deletion directly from where I need it!

This has been verified to work in a Notebook. I didn't write a test for it, as the data sources test is being currently skipped as 'outdated'.