### PR TITLE
Fix issue #148

### DIFF
--- a/cate/ops/__init__.py
+++ b/cate/ops/__init__.py
@@ -38,6 +38,12 @@ information.
 Functions
 ==========
 """
+# We need cate_init being accessible to use by the plugin registering logic
+# before any attempt to import any of the submodules is made. See Issue #148
+def cate_init():
+    # Plugin initializer.
+    # Left empty because operations are registered automatically via decorators.
+    pass
 
 from .select import select_var
 from .coregistration import coregister
@@ -55,6 +61,7 @@ from .anomaly import anomaly_internal, anomaly_climatology
 from .index import nino34
 from .ident import *
 from .outliers import detect_outliers
+
 
 __all__ = [
     # .timeseries
@@ -102,9 +109,3 @@ __all__ = [
     # .outliers
     'detect_outliers',
 ]
-
-
-def cate_init():
-    # Plugin initializer.
-    # Left empty because operations are registered automatically via decorators.
-    pass

--- a/cate/ops/anomaly.py
+++ b/cate/ops/anomaly.py
@@ -30,7 +30,7 @@ Functions
 """
 
 from cate.core.op import op
-from cate.ops import subset_spatial, subset_temporal
+from cate.ops.subset import subset_spatial, subset_temporal
 import xarray as xr
 
 

--- a/cate/ops/average.py
+++ b/cate/ops/average.py
@@ -35,7 +35,8 @@ import xarray as xr
 
 from cate.core.ds import DATA_STORE_REGISTRY, query_data_sources
 from cate.core.op import op, op_input
-from cate.ops import select_var, save_dataset
+from cate.ops.select import select_var
+from cate.ops.io import save_dataset
 from cate.util import to_datetime_range, to_datetime
 from cate.util.monitor import Monitor
 

--- a/cate/ops/coregistration.py
+++ b/cate/ops/coregistration.py
@@ -40,6 +40,8 @@ import numpy as np
 import xarray as xr
 
 from cate.core.op import op_input, op
+
+# This imports ops/resampling.py, instead of a name from ops.__init__
 from cate.ops import resampling
 
 

--- a/cate/ops/index.py
+++ b/cate/ops/index.py
@@ -31,7 +31,8 @@ Functions
 """
 
 from cate.core.op import op
-from cate.ops import subset_spatial, select_var
+from cate.ops.select import select_var
+from cate.ops.subset import subset_spatial
 import xarray as xr
 
 

--- a/cate/ops/outliers.py
+++ b/cate/ops/outliers.py
@@ -105,7 +105,7 @@ def _mask_outliers(ds: xr.Dataset, var_name: str, threshold_low: float,
     Create a mask data array for the given variable of the dataset and given
     absolute threshold values. Add the mask data array as an ancillary data
     array to the original array as per CF conventions.
-    
+
     For explanation about the relevant attributes, see::
     http://cfconventions.org/cf-conventions/v1.6.0/cf-conventions.html#flags
     http://cfconventions.org/cf-conventions/v1.6.0/cf-conventions.html#ancillary-data


### PR DESCRIPTION
Fix circular imports in operations, make sure ops:cate_init can be
invoked upon importing ops, before any attempt is made to import any of
the submodules.