### PR TITLE
46 type validation

### DIFF
--- a/cate/core/op.py
+++ b/cate/core/op.py
@@ -560,7 +560,7 @@ def op_return(data_type=None,
 
 def _update_properties(old_properties: dict, new_properties: dict):
     for name, value in new_properties.items():
-        if value is not None and (name not in old_properties or old_properties[name] is None):
+        if value is not None:
             old_properties[name] = value
 
 

--- a/cate/core/types.py
+++ b/cate/core/types.py
@@ -51,7 +51,7 @@ and add the new definition to TYPES.
 
 """
 from abc import ABCMeta, abstractmethod
-from typing import Union, Any, List, Optional
+from typing import Union, Any, List
 
 from cate.util.misc import to_list
 
@@ -155,7 +155,7 @@ _TYPES = {POLYGON: _Polygon,
 
 def is_type(value: Any, maybe_type: Any) -> bool:
     """
-    Replacement for the built in isinstance() that works with custom Cate
+    Replacement for the built-in isinstance() that works with custom Cate
     types.
 
     :param value: Value to check
@@ -186,6 +186,3 @@ def to_op_object(value: Any, typ: Any) -> Any:
     :param typ: Complex type
     """
     return _TYPES[typ]._to_op_object(value)
-
-print(is_type(0.45, VARIABLE))
-print(to_op_object('aa,bb,cc', VARIABLE))

--- a/cate/core/types.py
+++ b/cate/core/types.py
@@ -1,0 +1,131 @@
+
+# The MIT License (MIT)
+# Copyright (c) 2016, 2017 by the ESA CCI Toolbox development team and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+__author__ = "Janis Gailis (S[&]T Norway)"
+
+"""
+Description
+===========
+
+Implementation of custom complex types and appropriate validation routines
+
+Use TYPE_ALIAS in method signature for static type checking, use
+is_type(value, TYPE) as a replacement for the built-in isinstance() for
+complex 'typing' based types.
+
+For example::
+
+@op
+@op_input('name1', data_type=TYPE)
+def some_op(name1: TYPE_ALIAS -> TypeNotation[TYPE]:
+    # Do something useful
+    pass
+
+To add a new type, add a new type definition, an alias and a validation
+function and add the new definition to _IS_TYPE.
+
+"""
+from typing import Union, Any, List, Optional
+
+# Using strings instead of ints for better debug message readability down the
+# line
+POLYGON = 'POLYGON'
+POLYGON_ALIAS = Union[str, List[str]]
+
+VARIABLE = 'VARIABLE'
+VARIABLE_ALIAS = Union[str, List[str]]
+
+TIME_SELECTION = 'TIME_SELECTION'
+TIME_SELECTION_ALIAS = Union[str, List[str]]
+
+
+def _is_polygon(val: Any) -> bool:
+    """
+    Check if the given value belongs to the POLYGON type
+
+    :param val: Value to check
+    """
+    return False
+
+
+def _is_variable(val: Any) -> bool:
+    """
+    Check if the given value belongs to the VARIABLE type
+
+    :param val: Value to check
+    """
+    if isinstance(val, str):
+        # It's a single string, yay!
+        return True
+
+    if isinstance(val, list):
+        # It's a list, yay!
+        for item in val:
+            if not isinstance(item, str):
+                # But at least one item is not a string, darn.
+                return False
+
+        # It's a list of strings, yay!
+        return True
+
+    # It's something else completely
+    return False
+
+
+def _is_time_selection(val: Any) -> bool:
+    """
+    Check if the given value belongs to the TIME_SELECTION type
+
+    :param val: Value to check
+    """
+    return False
+
+
+_IS_TYPE = {POLYGON: _is_polygon,
+            VARIABLE: _is_variable,
+            TIME_SELECTION: _is_time_selection}
+
+
+def is_type(value: Any, maybe_type: Any) -> bool:
+    """
+    Replacement for the built in isinstance() that works with custom Cate
+    types.
+
+    :param value: Value to check
+    :param maybe_type: type to check
+    """
+    try:
+        return isinstance(value, maybe_type)
+    except TypeError:
+        if not isinstance(maybe_type, str):
+            # maybe_type is not a string, probably we have a complex
+            # constructed type using typing package Union or Sequence
+            raise TypeError('Not possible to explicitly validate {}'
+                            ' types. Have you forgotten to add data_value=TYPE'
+                            ' in @op_input decorator?'.format(maybe_type))
+
+    if maybe_type not in _IS_TYPE:
+        raise TypeError('Provided type definition {} not'
+                        ' found'.format(maybe_type))
+    # Now we should have a valid type definition
+
+    return _IS_TYPE[maybe_type](value)

--- a/cate/core/types.py
+++ b/cate/core/types.py
@@ -169,7 +169,7 @@ def is_type(value: Any, maybe_type: Any) -> bool:
             # constructed type using typing package Union or Sequence
             raise TypeError('Not possible to explicitly validate {}'
                             ' types. Have you forgotten to add data_value=TYPE'
-                            ' in @op_input decorator?'.format(maybe_type))
+                            ' to @op_input decorator?'.format(maybe_type))
 
     if maybe_type not in _TYPES:
         raise TypeError('Provided type definition {} not'
@@ -178,11 +178,11 @@ def is_type(value: Any, maybe_type: Any) -> bool:
 
     return _TYPES[maybe_type]._is_type(value)
 
-def to_op_object(value: Any, typ: Any) -> Any:
+def to_op_object(value: Any, custom_type: Any) -> Any:
     """
     Return an object that operations expect to work with for the given type
 
     :param value: Value to process
-    :param typ: Complex type
+    :param custom_type: Complex type
     """
-    return _TYPES[typ]._to_op_object(value)
+    return _TYPES[custom_type]._to_op_object(value)

--- a/cate/ops/select.py
+++ b/cate/ops/select.py
@@ -36,11 +36,9 @@ import xarray as xr
 
 from cate.core.op import op, op_input
 from cate.util import to_list
-from cate.core.types import VARIABLE, VARIABLE_ALIAS
+from cate.core.types import VARIABLE, VARIABLE_ALIAS, to_op_object
 
 
-# TODO (Gailis, 27.09.16) See issues #45 and #46
-#def select_var(ds: xr.Dataset, var: str = None) -> xr.Dataset:
 @op_input('var', data_type=VARIABLE)
 @op(tags=['select', 'subset', 'filter', 'var'])
 def select_var(ds: xr.Dataset, var: VARIABLE_ALIAS = None) -> xr.Dataset:
@@ -59,7 +57,7 @@ def select_var(ds: xr.Dataset, var: VARIABLE_ALIAS = None) -> xr.Dataset:
     if not var:
         return ds
 
-    var_names = to_list(var, name='var')
+    var_names = to_op_object(var, VARIABLE)
     dropped_var_names = list(ds.data_vars.keys())
 
     for pattern in var_names:

--- a/cate/ops/select.py
+++ b/cate/ops/select.py
@@ -34,14 +34,16 @@ import fnmatch
 import geopandas as gpd
 import xarray as xr
 
-from cate.core.op import op
+from cate.core.op import op, op_input
 from cate.util import to_list
+from cate.core.types import VARIABLE, VARIABLE_ALIAS
 
 
-@op(tags=['select', 'subset', 'filter', 'var'])
 # TODO (Gailis, 27.09.16) See issues #45 and #46
-#def select_var(ds: xr.Dataset, var: Union[None, str, List[str]] = None) -> xr.Dataset:
-def select_var(ds: xr.Dataset, var: str = None) -> xr.Dataset:
+#def select_var(ds: xr.Dataset, var: str = None) -> xr.Dataset:
+@op_input('var', data_type=VARIABLE)
+@op(tags=['select', 'subset', 'filter', 'var'])
+def select_var(ds: xr.Dataset, var: VARIABLE_ALIAS = None) -> xr.Dataset:
     """
     Filter the dataset, by leaving only the desired variables in it. The original dataset
     information, including original coordinates, is preserved.

--- a/cate/util/opmetainf.py
+++ b/cate/util/opmetainf.py
@@ -320,10 +320,15 @@ class OpMetaInfo:
             # TODO (forman, 20160907): perform more elaborated input type checking here (issue #46)
             is_float_type = data_type is float and (isinstance(value, float) or isinstance(value, int))
             if data_type and not (is_type(value, data_type) or is_float_type):
+                try:
+                    dt_name = data_type.__name__
+                except AttributeError:
+                    # data_type is Cate complex type, which is defined by a str
+                    dt_name = data_type
                 raise ValueError(
                     "input '%s' for operation '%s' must be of type '%s', but got type '%s'" % (
-                        name, self.qualified_name, str(data_type),
-                        str(type(value))))
+                        name, self.qualified_name, dt_name,
+                        type(value).__name__))
             value_set = input_properties.get('value_set', None)
             if value_set and (value not in value_set):
                 raise ValueError(

--- a/cate/util/opmetainf.py
+++ b/cate/util/opmetainf.py
@@ -27,6 +27,7 @@ from inspect import isclass
 from typing import Tuple, Dict, List
 
 from cate.util import object_to_qualified_name, qualified_name_to_object
+from cate.core.types import is_type
 
 
 class OpMetaInfo:
@@ -318,10 +319,11 @@ class OpMetaInfo:
             data_type = input_properties.get('data_type', None)
             # TODO (forman, 20160907): perform more elaborated input type checking here (issue #46)
             is_float_type = data_type is float and (isinstance(value, float) or isinstance(value, int))
-            if data_type and not (isinstance(value, data_type) or is_float_type):
+            if data_type and not (is_type(value, data_type) or is_float_type):
                 raise ValueError(
                     "input '%s' for operation '%s' must be of type '%s', but got type '%s'" % (
-                        name, self.qualified_name, data_type.__name__, type(value).__name__))
+                        name, self.qualified_name, str(data_type),
+                        str(type(value))))
             value_set = input_properties.get('value_set', None)
             if value_set and (value not in value_set):
                 raise ValueError(
@@ -348,7 +350,7 @@ class OpMetaInfo:
             if value is not None:
                 data_type = output_properties.get('data_type', None)
                 # TODO (forman, 20160907): perform more elaborated output type checking here (issue #46)
-                if data_type and not isinstance(value, data_type):
+                if data_type and not is_type(value, data_type):
                     raise ValueError(
                         "output '%s' for operation '%s' must be of type %s" % (
                             name, self.qualified_name, data_type))

--- a/test/core/test_types.py
+++ b/test/core/test_types.py
@@ -1,0 +1,61 @@
+from unittest import TestCase
+
+from cate.core import types
+from typing import Union, List, NewType
+
+
+class TestTypes(TestCase):
+    def test_interface(self):
+        """
+        Test the overall complex types interface
+        """
+        DOESNTEXIST = 'DOESNTEXIST'
+        AliasedType = Union[str, List[str]]
+        MyType = NewType('MyType', Union[str, List[str]])
+        is_type = types.is_type
+
+        with self.assertRaises(TypeError) as err:
+            is_type('aa', 1.0)
+        self.assertTrue('Not possible' in str(err.exception))
+
+        with self.assertRaises(TypeError) as err:
+            is_type('aa', DOESNTEXIST)
+        self.assertTrue('DOESNTEXIST' in str(err.exception))
+
+        with self.assertRaises(TypeError) as err:
+            is_type('aa', Union[str, List[str]])
+        self.assertTrue('Union[str,' in str(err.exception))
+
+        with self.assertRaises(TypeError) as err:
+            is_type('aa', AliasedType)
+        self.assertTrue('Union[str,' in str(err.exception))
+
+        with self.assertRaises(TypeError) as err:
+            is_type('aa', MyType)
+        self.assertTrue('Not possible' in str(err.exception))
+
+
+        self.assertTrue(is_type('aa', types.VARIABLE))
+
+    def test_variable_type(self):
+        """
+        Test the VARIABLE type
+        """
+        VARIABLE = types.VARIABLE
+        is_type = types.is_type
+        to_op_object = types.to_op_object
+
+        self.assertTrue(is_type('aa', VARIABLE))
+        self.assertTrue(is_type('aa,bb,cc', VARIABLE))
+        self.assertTrue(is_type(['aa', 'bb', 'vv'], VARIABLE))
+        self.assertFalse(is_type(1.0, VARIABLE))
+        self.assertFalse(is_type([1, 2, 4], VARIABLE))
+        self.assertFalse(is_type(['aa', 2, 'bb'], VARIABLE))
+
+        expected = ['aa', 'bb', 'cc']
+        actual = to_op_object('aa,bb,cc', VARIABLE)
+        self.assertEqual(actual, expected)
+
+        with self.assertRaises(TypeError) as err:
+            to_op_object(['aa', 1, 'bb'], VARIABLE)
+        self.assertTrue('Provided value' in str(err.exception))

--- a/test/ops/test_select.py
+++ b/test/ops/test_select.py
@@ -3,6 +3,8 @@ from unittest import TestCase
 import xarray as xr
 
 from cate.ops.select import select_var
+from cate.core.op import OP_REGISTRY
+from cate.util.misc import object_to_qualified_name
 
 
 class TestSelect(TestCase):
@@ -36,6 +38,18 @@ class TestSelect(TestCase):
         # Test that wildcard selection works
         actual = select_var(dataset, var='*b*')
         self.assertDatasetEqual(dataset, actual)
+
+    def test_select_registry(self):
+        """
+        Test the select operation invocation from the operation registry, as
+        done by the GUI and the CLI. This tests the @op* decorators in
+        conjunction with this op.
+        """
+        dataset = xr.Dataset({'abc': ('x', [1, 2, 3]),
+                              'bde': ('x', [4, 5, 6])})
+        op_reg = OP_REGISTRY.get_op(object_to_qualified_name(select_var))
+
+        actual = op_reg(ds=dataset, var='aa')
 
     def assertDatasetEqual(self, expected, actual):
         # this method is functionally equivalent to `assert expected == actual`, but it


### PR DESCRIPTION
Fixes issue #46 

Goes a long way towards resolving #130 and #72 

The main idea is an added core module types.py that lets us define complex types, as well as some auxiliary methods for working with these, such as validation routines, resolving routines, or anything else we might want to have. Then the types can be used as:
```python
from op.core.types import TYPE, TYPE_ALIAS, is_type, to_op_object

@op
@op_input('name1', data_type=TYPE)
def some_op(name1: TYPE_ALIAS):
   # Get the 'default' object (a List, a Shapely shape, a Pandas Dataframe)
   name1 = to_op_object(name1, TYPE) 
   # Do something
   pass
```
or more generally:
```python
def some_method(name1: TYPE_ALIAS):
    # Use instead of isinstance()
    is_type(name1, TYPE)
    # Do something useful
    pass
```

I haven't paid too much attention to code architecture, so everything is in a single file, without exported imports to core. This is because I'd like to have your opinion on where this should go and how this would fit in the overall architecture. Should it go into util, core, separate 'types' folder under cate?. Should the abstract interface class be split out and left in core, while the defintions of particular types go to the 'types' folder, as with 'ds')?

Any comments welcome!