### PR TITLE
292 jg autotags

### DIFF
--- a/cate/core/op.py
+++ b/cate/core/op.py
@@ -397,8 +397,10 @@ def op(registry=OP_REGISTRY, **properties):
         op_registration = registry.add_op(op_func, fail_if_exists=False)
         try:
             default_tags = op_registration.op_meta_info.header['tags']
-            properties['tags'] = default_tags + properties['tags']
+            if default_tags[0] not in properties['tags']:
+                properties['tags'] = default_tags + properties['tags']
         except KeyError:
+            # The user has not provided any tags
             pass
         op_registration.op_meta_info.header.update({k: v for k, v in properties.items() if v is not UNDEFINED})
         return op_registration

--- a/cate/core/op.py
+++ b/cate/core/op.py
@@ -395,6 +395,11 @@ def op(registry=OP_REGISTRY, **properties):
 
     def decorator(op_func):
         op_registration = registry.add_op(op_func, fail_if_exists=False)
+        try:
+            default_tags = op_registration.op_meta_info.header['tags']
+            properties['tags'] = default_tags + properties['tags']
+        except KeyError:
+            pass
         op_registration.op_meta_info.header.update({k: v for k, v in properties.items() if v is not UNDEFINED})
         return op_registration
 

--- a/cate/util/opmetainf.py
+++ b/cate/util/opmetainf.py
@@ -237,6 +237,9 @@ class OpMetaInfo:
                 if return_description and return_name in output_dict:
                     output_dict[return_name]['description'] = return_description
 
+        if hasattr(operation, '__module__'):
+            header['tags'] = [operation.__module__.split('.')[-1]]
+
         return OpMetaInfo(op_qualified_name,
                           header_dict=header,
                           has_monitor=has_monitor,

--- a/test/core/test_op.py
+++ b/test/core/test_op.py
@@ -45,7 +45,7 @@ class OpTest(TestCase):
         expected_outputs[RETURN] = dict(data_type=str)
         self._assertMetaInfo(op_reg.op_meta_info,
                              object_to_qualified_name(f),
-                             dict(description='Hi, I am f!'),
+                             dict(description='Hi, I am f!', tags=['test_op']),
                              expected_inputs,
                              expected_outputs)
 
@@ -58,7 +58,7 @@ class OpTest(TestCase):
             registry.remove_op(f, fail_if_not_exists=True)
 
     def test_f_op(self):
-        @op(registry=self.registry)
+        @op(registry=self.registry, tags=['some_tag'])
         def f_op(a: float, b, c, u=3, v='A', w=4.9) -> str:
             """Hi, I am f_op!"""
             return str(a + b + c + u + len(v) + w)
@@ -79,7 +79,8 @@ class OpTest(TestCase):
         expected_outputs[RETURN] = dict(data_type=str)
         self._assertMetaInfo(op_reg.op_meta_info,
                              object_to_qualified_name(f_op),
-                             dict(description='Hi, I am f_op!'),
+                             dict(description='Hi, I am f_op!',
+                                  tags=['test_op', 'some_tag']),
                              expected_inputs,
                              expected_outputs)
 
@@ -107,7 +108,8 @@ class OpTest(TestCase):
         expected_outputs[RETURN] = dict(data_type=str)
         self._assertMetaInfo(op_reg.op_meta_info,
                              object_to_qualified_name(f_op_inp_ret),
-                             dict(description='Hi, I am f_op_inp_ret!'),
+                             dict(description='Hi, I am f_op_inp_ret!',
+                                  tags=['test_op']),
                              expected_inputs,
                              expected_outputs)
 

--- a/test/core/test_op.py
+++ b/test/core/test_op.py
@@ -85,9 +85,10 @@ class OpTest(TestCase):
                              expected_outputs)
 
     def test_f_op_inp_ret(self):
+        @op(registry=self.registry, tags=['test_op', 'some_tag'])
         @op_input('a', value_range=[0., 1.], registry=self.registry)
         @op_input('v', value_set=['A', 'B', 'C'], registry=self.registry)
-        @op_return(registry=self.registry)
+        @op_return()
         def f_op_inp_ret(a: float, b, c, u=3, v='A', w=4.9) -> str:
             """Hi, I am f_op_inp_ret!"""
             return str(a + b + c + u + len(v) + w)
@@ -109,7 +110,7 @@ class OpTest(TestCase):
         self._assertMetaInfo(op_reg.op_meta_info,
                              object_to_qualified_name(f_op_inp_ret),
                              dict(description='Hi, I am f_op_inp_ret!',
-                                  tags=['test_op']),
+                                  tags=['test_op', 'some_tag']),
                              expected_inputs,
                              expected_outputs)
 

--- a/test/util/test_opmetainfo.py
+++ b/test/util/test_opmetainfo.py
@@ -48,7 +48,8 @@ class OpMetaInfoTest(TestCase):
 
         op_meta_info = OpMetaInfo.introspect_operation(f)
         self.assertEqual(op_meta_info.qualified_name, object_to_qualified_name(f))
-        self.assertEqual(op_meta_info.header, dict(description='The doc.'))
+        self.assertEqual(op_meta_info.header, dict(description='The doc.',
+                                                   tags=['test_opmetainfo']))
         self.assertEqual(len(op_meta_info.input), 4)
         self.assertEqual(len(op_meta_info.output), 1)
         self.assertIn('a', op_meta_info.input)
@@ -72,7 +73,8 @@ class OpMetaInfoTest(TestCase):
 
         op_meta_info = OpMetaInfo.introspect_operation(g)
         self.assertEqual(op_meta_info.qualified_name, object_to_qualified_name(g))
-        self.assertEqual(op_meta_info.header, dict(description='The doc.'))
+        self.assertEqual(op_meta_info.header, dict(description='The doc.',
+                                                   tags=['test_opmetainfo']))
         self.assertEqual(len(op_meta_info.input), 1)
         self.assertEqual(len(op_meta_info.output), 1)
         self.assertIn('x', op_meta_info.input)


### PR DESCRIPTION
Introduce automatic operation tagging with the module name.

Closes #292 